### PR TITLE
Create ProfileCard component and render sample cards

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,49 +1,50 @@
-import { ScrollView, StyleSheet } from "react-native";
+import { ScrollView, StyleSheet, View } from "react-native";
+import ProfileCard from "@/components/ProfileCard";
 
 const USERS_DATA = [
-  { id: '1', nom: 'Alice Martin', email: 'alice.martin@email.com' },
-  { id: '2', nom: 'Benjamin Dubois', email: 'ben.dubois@email.com' },
-  { id: '3', nom: 'Chloé Garcia', email: 'chloe.g@email.com' },
-  { id: '4', nom: 'David Petit', email: 'david.petit@email.com' },
-  { id: '5', nom: 'Émilie Rousseau', email: 'emilie.rousseau@email.com' },
+  {
+    id: "1",
+    name: "Alice Martin",
+    jobTitle: "React Native Developer",
+    imageUrl: "https://picsum.photos/seed/alice/200/200",
+  },
+  {
+    id: "2",
+    name: "Benjamin Dubois",
+    jobTitle: "Product Designer",
+    imageUrl: "https://picsum.photos/seed/benjamin/200/200",
+  },
+  {
+    id: "3",
+    name: "Chloé Garcia",
+    jobTitle: "Project Manager",
+    imageUrl: "https://picsum.photos/seed/chloe/200/200",
+  },
 ];
-
 
 export default function HomeScreen() {
   return (
-      <ScrollView>
-        { /* Render the list of users using the UserItem component */ }
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {USERS_DATA.map((user) => (
+          <ProfileCard
+            key={user.id}
+            name={user.name}
+            jobTitle={user.jobTitle}
+            imageUrl={user.imageUrl}
+          />
+        ))}
       </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "#f5f5f5",
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    textAlign: 'center',
-    marginVertical: 20,
-  },
-  item: {
-    backgroundColor: '#ffffff',
-    padding: 20,
-    marginVertical: 8,
-    marginHorizontal: 16,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#ddd',
-  },
-  nom: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  email: {
-    fontSize: 14,
-    color: '#666',
-    marginTop: 4,
+  scrollContent: {
+    paddingVertical: 24,
   },
 });

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -1,24 +1,21 @@
 import React from "react";
-import { StyleSheet, Text } from "react-native";
+import { Image, StyleSheet, Text, View } from "react-native";
 
-// Define the props interface for type safety
 interface ProfileCardProps {
   name: string;
   jobTitle: string;
   imageUrl: string;
 }
 
-// The component receives 'props' as an argument.
-// We use destructuring to get the values we need directly.
-const ProfileCard: React.FC<ProfileCardProps> = ({
-  name,
-  jobTitle,
-  imageUrl,
-}) => {
+const ProfileCard: React.FC<ProfileCardProps> = ({ name, jobTitle, imageUrl }) => {
   return (
-    <>
-      <Text>Replace this part with your soluce</Text>
-    </>
+    <View style={styles.card}>
+      <Image source={{ uri: imageUrl }} style={styles.image} accessibilityRole="image" />
+      <View style={styles.textContainer}>
+        <Text style={styles.name}>{name}</Text>
+        <Text style={styles.jobTitle}>{jobTitle}</Text>
+      </View>
+    </View>
   );
 };
 
@@ -27,7 +24,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     borderRadius: 16,
     padding: 20,
-    margin: 16,
+    marginVertical: 8,
+    marginHorizontal: 16,
     flexDirection: "row",
     alignItems: "center",
     shadowColor: "#000",
@@ -51,6 +49,7 @@ const styles = StyleSheet.create({
   jobTitle: {
     fontSize: 16,
     color: "gray",
+    marginTop: 4,
   },
 });
 


### PR DESCRIPTION
## Summary
- build a reusable `ProfileCard` component that accepts a name, job title, and image URL
- render example profile cards on the home tab using the new component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e581d2815c83338e619e6b7ba41f86